### PR TITLE
fix(log): 修复打印response时，拷贝数据导致oom

### DIFF
--- a/okhttploginterceptor/gradle.properties
+++ b/okhttploginterceptor/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=3.0.8
+VERSION_NAME=3.0.9
 
 POM_NAME=okhttploginterceptor
 POM_ARTIFACT_ID=okhttploginterceptor

--- a/okhttploginterceptor/src/main/java/com/ayvytr/okhttploginterceptor/LoggingInterceptor.kt
+++ b/okhttploginterceptor/src/main/java/com/ayvytr/okhttploginterceptor/LoggingInterceptor.kt
@@ -152,7 +152,7 @@ class LoggingInterceptor @JvmOverloads constructor(var showLog: Boolean = true,
         }
 
         responseBody?.also {
-            val peekBody = response.peekBody(Long.MAX_VALUE)
+            val peekBody = response.peekBody(1024)
             if (isShowAll && responseBody.contentLength() == -1L) {
                 list.add("$L Content-Length: ${peekBody.contentLength()}")
             }


### PR DESCRIPTION
暂时将response打印的大小定位1024子节